### PR TITLE
-P option fix

### DIFF
--- a/unipkg.sh.in
+++ b/unipkg.sh.in
@@ -2252,7 +2252,7 @@ fi
 ARGLIST=("$@")
 
 # Parse Command Line Options.
-OPT_SHORT="AcdefFghiLmop:rRsSV"
+OPT_SHORT="AcdefFghiLmopP:rRsSV"
 OPT_LONG="allsource,asroot,ignorearch,check,clean,nodeps"
 OPT_LONG+=",noextract,force,forcever:,geninteg,help,holdver,skippgpcheck"
 OPT_LONG+=",install,key:,log,nocolor,nobuild,nocheck,nosign,pkg:,rmdeps"


### PR DESCRIPTION
I tried to use the command:
unipkg -P debian
and it said that -P wasn't an option.
So i just added the "P" char in OPT_SHORT
I guess it's just an unwanted edit mistake...
Just for curiosity, what is the purpose or the ":" in OPT_SHORT ?
